### PR TITLE
Fixed printing passwords that contain special chars

### DIFF
--- a/mimipenguin.sh
+++ b/mimipenguin.sh
@@ -200,5 +200,5 @@ if [[ -e "/etc/ssh/sshd_config" ]]; then
 fi
 #Output results to STDOUT
 printf "MimiPenguin Results:\n"
-printf "$RESULTS" | sort -u
+printf "%b" "$RESULTS" | sort -u
 unset RESULTS


### PR DESCRIPTION
Hello,

I tested mimipenguin on my Debian 8 system and noticed that if a password contains special chars such as '%' or '!' the script is breaking with:

MimiPenguin Results:
./mimipenguin.sh: line 204: printf: `!': invalid format character
[SYSTEM - GNOME]			user:passw

To fix this I added "%b" to printf on the line 203 and after that passwords were properly printed out.

Great project, hope to see it evolve further :)