### PR TITLE
Replaced Ubuntu Desktop dumper with Gnome Keyring dumper (ArchLinux Desktop support) and Kali Desktop dumper with GDM dumper (Debian Desktop support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ MimiPenguin is slowly being ported to multiple languages to support all possible
 |--------------------------------------------|-----|-----|
 | Kali Desktop Password (gdm3)               | X   | X   |
 | Ubuntu Desktop Password (Gnome Keyring)    | X   | X   |
-| Arch Desktop Password (Gnome Keyring)      | X   |     |
+| Arch Desktop Password (Gnome Keyring)      | X   | X   |
 | VSFTPd (Active FTP Connections)            | X   | X   |
 | Apache2 (Active HTTP Basic Auth Sessions)  | ~   | ~   |
 | OpenSSH (Active SSH Sessions - Sudo Usage) | ~   | ~   |

--- a/README.md
+++ b/README.md
@@ -30,14 +30,13 @@ Takes advantage of cleartext credentials in memory by dumping the process and ex
 ## Development Roadmap
 MimiPenguin is slowly being ported to multiple languages to support all possible post-exploit scenarios. The roadmap below was suggested by KINGSABRI to track the various versions and features. An "X" denotes full support while a "~" denotes a feature with known bugs.
 
-| Feature                                    | .sh | .py |
-|--------------------------------------------|-----|-----|
-| Kali Desktop Password (gdm3)               | X   | X   |
-| Ubuntu Desktop Password (Gnome Keyring)    | X   | X   |
-| Arch Desktop Password (Gnome Keyring)      | X   | X   |
-| VSFTPd (Active FTP Connections)            | X   | X   |
-| Apache2 (Active HTTP Basic Auth Sessions)  | ~   | ~   |
-| OpenSSH (Active SSH Sessions - Sudo Usage) | ~   | ~   |
+| Feature                                           | .sh | .py |
+|---------------------------------------------------|-----|-----|
+| GDM password (Kali Desktop, Debian Desktop)       | ~   | X   |
+| Gnome Keyring (Ubuntu Desktop, ArchLinux Desktop) | X   | X   |
+| VSFTPd (Active FTP Connections)                   | X   | X   |
+| Apache2 (Active HTTP Basic Auth Sessions)         | ~   | ~   |
+| OpenSSH (Active SSH Sessions - Sudo Usage)        | ~   | ~   |
 
 ## Contact
 * Twitter: [@huntergregal](https://twitter.com/HunterGregal)

--- a/mimipenguin.py
+++ b/mimipenguin.py
@@ -148,7 +148,7 @@ class PasswordFinder:
 
         return self._try_potential_passwords()
 
-class KaliDesktopPasswordFinder(PasswordFinder):
+class GdmPasswordFinder(PasswordFinder):
     def __init__(self):
         PasswordFinder.__init__(self)
         self._source_name = '[SYSTEM - GNOME]'
@@ -212,8 +212,8 @@ def main():
 
     password_finders = list()
 
-    if 'kali' in get_linux_distribution():
-        password_finders.append(KaliDesktopPasswordFinder())
+    if find_pid('gdm-password'):
+        password_finders.append(GdmPasswordFinder())
     if find_pid('gnome-keyring-daemon'):
         password_finders.append(GnomeKeyringPasswordFinder())
     if os.path.isfile('/etc/vsftpd.conf'):

--- a/mimipenguin.py
+++ b/mimipenguin.py
@@ -155,7 +155,7 @@ class KaliDesktopPasswordFinder(PasswordFinder):
         self._target_processes = ['gdm-password']
         self._needles = ['^_pammodutil_getpwnam_root_1$', '^gkr_system_authtok$']
 
-class UbuntuDesktopPasswordFinder(PasswordFinder):
+class GnomeKeyringPasswordFinder(PasswordFinder):
     def __init__(self):
         PasswordFinder.__init__(self)
         self._source_name = '[SYSTEM - GNOME]'
@@ -214,8 +214,8 @@ def main():
 
     if 'kali' in get_linux_distribution():
         password_finders.append(KaliDesktopPasswordFinder())
-    if 'ubuntu' in get_linux_distribution():
-        password_finders.append(UbuntuDesktopPasswordFinder())
+    if find_pid('gnome-keyring-daemon'):
+        password_finders.append(GnomeKeyringPasswordFinder())
     if os.path.isfile('/etc/vsftpd.conf'):
         password_finders.append(VsftpdPasswordFinder())
     if os.path.isfile('/etc/ssh/sshd_config'):


### PR DESCRIPTION
Hi @huntergregal,

I replaced the Ubuntu Desktop dumper with a generic Gnome keyring dumper, so that you could add the Arch Linux support for the Python script in your roadmap.

Cheers,

Y