### PR TITLE
Updated README.md to add OpenSUSE 42.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Takes advantage of cleartext credentials in memory by dumping the process and ex
 * Ubuntu Desktop 16.04 LTS x64 (Gnome Keyring 3.18.3-0ubuntu2)
 * XUbuntu Desktop 16.04 x64 (Gnome Keyring 3.18.3-0ubuntu2)
 * Archlinux x64 Gnome 3 (Gnome Keyring 3.20)
+* OpenSUSE Leap 42.2 x64 (Gnome Keyring 3.20)
 * VSFTPd 3.0.3-8+b1 (Active FTP client connections)
 * Apache2 2.4.25-3 (Active/Old HTTP BASIC AUTH Sessions) [Gcore dependency]
 * openssh-server 1:7.3p1-1 (Active SSH connections - sudo usage)


### PR DESCRIPTION
Tested on OpenSUSE Leap 42.2. Only the Python script worked. The shell script did not work.