### PR TITLE
Add a `linux-vdso.so.1` needle for `gnome-keyring-daemon`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Takes advantage of cleartext credentials in memory by dumping the process and ex
 * Ubuntu Desktop 12.04 LTS x64 (Gnome Keyring 3.18.3-0ubuntu2)
 * Ubuntu Desktop 14.04.1 LTS x64 (Gnome Keyring 3.10.1-1ubuntu4.3, LightDM 1.10.6-0ubuntu1)
 * Ubuntu Desktop 16.04 LTS x64 (Gnome Keyring 3.18.3-0ubuntu2)
-* Ubuntu Desktop 16.04.4 LTS x64 (LightDM 1.18.3-0ubuntu1.1)
+* Ubuntu Desktop 16.04.4 LTS x64 (Gnome Keyring 3.18.3-0ubuntu2, LightDM 1.18.3-0ubuntu1.1)
 * XUbuntu Desktop 16.04 x64 (Gnome Keyring 3.18.3-0ubuntu2)
 * Archlinux x64 Gnome 3 (Gnome Keyring 3.20)
 * OpenSUSE Leap 42.2 x64 (Gnome Keyring 3.20)
@@ -36,7 +36,7 @@ MimiPenguin is slowly being ported to multiple languages to support all possible
 | Feature                                           | .sh | .py |
 |---------------------------------------------------|-----|-----|
 | GDM password (Kali Desktop, Debian Desktop)       | ~   | X   |
-| Gnome Keyring (Ubuntu Desktop, ArchLinux Desktop) | X   | X   |
+| Gnome Keyring (Ubuntu Desktop, ArchLinux Desktop) | ~   | X   |
 | LightDM (Ubuntu Desktop)                          | X   | X   |
 | VSFTPd (Active FTP Connections)                   | X   | X   |
 | Apache2 (Active HTTP Basic Auth Sessions)         | ~   | ~   |

--- a/mimipenguin.py
+++ b/mimipenguin.py
@@ -181,7 +181,7 @@ class GnomeKeyringPasswordFinder(PasswordFinder):
         PasswordFinder.__init__(self)
         self._source_name = '[SYSTEM - GNOME]'
         self._target_processes = ['gnome-keyring-daemon']
-        self._needles = [r'^.+libgck\-1\.so\.0$', r'libgcrypt\.so\..+$']
+        self._needles = [r'^.+libgck\-1\.so\.0$', r'libgcrypt\.so\..+$', r'linux-vdso\.so\.1$']
 
 class LightDmPasswordFinder(PasswordFinder):
     def __init__(self):


### PR DESCRIPTION
Add a `linux-vdso.so.1` needle for `gnome-keyring-daemon` to `mimipenguin.py` to support Ubuntu 16 distros.

Fix #22
Fix #26