### PR TITLE
Ignore memory regions mapped from file

### DIFF
--- a/mimipenguin.sh
+++ b/mimipenguin.sh
@@ -24,7 +24,7 @@ function dump_pid () {
 	if [[ $system == "kali" ]]; then
 		mem_maps=$(grep -E "^[0-9a-f-]* r" /proc/"$pid"/maps | grep -E 'heap|stack' | cut -d' ' -f 1)
 	else
-		mem_maps=$(grep -E "^[0-9a-f-]* r" /proc/"$pid"/maps | cut -d' ' -f 1)
+		mem_maps=$(grep -E "^[0-9a-f-]* r" /proc/"$pid"/maps | grep -E -v 'lib|usr|bin' | cut -d' ' -f 1)
 	fi
 	while read -r memrange; do
 		memrange_start=$(echo "$memrange" | cut -d"-" -f 1)


### PR DESCRIPTION
This is a simple patch to ignore memory regions mapped from file in the `dump_pid` function. This is much faster, as it decreases the number of regions to be searched by more than half.

It uses an inverse grep for `lib|usr|bin` in the maps output. This is a rudimentary approach. Using an inverse grep for `fd:` in the region device field would be a better check, but the `fd:` notation for the region device field is only used on some systems (Fedora, CentOS).

I've tested this with LightDM and gnome on Ubuntu/XUbuntu, and gnome on Fedora and CentOS. I have no idea if it will have an adverse effect on vsftpd or ssh/sudo. It won't affect Apache, as Apache is searched using `gcore` rather than `dump_pid`.

On a related topic, for kali systems, I'm not really sure why a `'heap|stack'` match is used, and why there's a need to differentiate. It might be faster on kali systems, but complicates the code (unnecessarily?).
