### PR TITLE
Add 3.20.0 and 3.20.1 g_gnomeKeyringTargets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ This version of Mimipenguin sacrifices features and coverage (as opposed to the 
 * a supported target
 
 ## Supported
-| OS                           |   Service                        | Supported          |
-|------------------------------|----------------------------------|-------------------|
-| Ubuntu Desktop 12.04 LTS x64 | gnome-keyring-daemon (3.18.3)    | :heavy_check_mark: |
-| Ubuntu Desktop 16.04 LTS x64 | gnome-keyring-daemon (3.18.3)    | :heavy_check_mark: |
-| Kali-rolling x64             | gnome-keyring-daemon (3.28.0.2)  | :heavy_check_mark: |
+| OS                             |   Service                        | Supported          |
+|--------------------------------|----------------------------------|--------------------|
+| Ubuntu Desktop 12.04 LTS x64   | gnome-keyring-daemon (3.18.3)    | :heavy_check_mark: |
+| Ubuntu Desktop 16.04 LTS x64   | gnome-keyring-daemon (3.18.3)    | :heavy_check_mark: |
+| Fedora Workstation 25 (x86_64) | gnome-keyring-daemon (3.20.0)    | :heavy_check_mark: |
+| Fedora Workstation 27 (x86_64) | gnome-keyring-daemon (3.20.1)    | :heavy_check_mark: |
+| Kali-rolling x64               | gnome-keyring-daemon (3.28.0.2)  | :heavy_check_mark: |
 
 ## Contact
 * Twitter: [@huntergregal](https://twitter.com/HunterGregal)

--- a/src/gnomeKeyring.c
+++ b/src/gnomeKeyring.c
@@ -17,9 +17,19 @@ GnomeKeyringTarget g_gnomeKeyringTargets[] = {
         0
     },
     {
-    "3.28.0.2",
-    (void*)0x30abc0,
-    1
+        "3.20.0",
+        (void*)0x308BB8,
+        1
+    },
+    {
+        "3.20.1",
+        (void*)0x307BC0,
+        1
+    },
+    {
+        "3.28.0.2",
+        (void*)0x30abc0,
+        1
     }
 };
 


### PR DESCRIPTION
Tested on:

* Fedora Workstation 25 (x86_64) - gnome-keyring-daemon 3.20.0
* Fedora Workstation 27 (x86_64) - gnome-keyring-daemon 3.20.1