### PR TITLE
Ignore memory regions mapped from file

### DIFF
--- a/mimipenguin.py
+++ b/mimipenguin.py
@@ -69,6 +69,8 @@ def dump_process(pid):
 
     with open('/proc/{}/maps'.format(pid), 'r') as maps_file:
         for l in maps_file.readlines():
+            if re.search(r'lib|usr|bin', l):
+                continue
             memrange, attributes = l.split(' ')[:2]
             if attributes.startswith('r'):
                 memrange_start, memrange_stop = [


### PR DESCRIPTION
This is a simple patch to ignore memory regions mapped from file. This is much faster, decreasing the time required to complete by more than half.

Same as #38, but for `mimipenguin.py` rather than `mimipenguin.sh`.

In retrospect, it appears this change, and the change in #38, causes mimipenguin to no longer retrieve credentials from `gnome-password`.
