### PR TITLE
Revert #38

### DIFF
--- a/mimipenguin.sh
+++ b/mimipenguin.sh
@@ -43,7 +43,7 @@ function dump_pid () {
 	if [[ $system == "kali" ]]; then
 		mem_maps=$(grep -E "^[0-9a-f-]* r" /proc/"$pid"/maps | grep -E 'heap|stack' | cut -d' ' -f 1)
 	else
-		mem_maps=$(grep -E "^[0-9a-f-]* r" /proc/"$pid"/maps | grep -E -v 'lib|usr|bin' | cut -d' ' -f 1)
+		mem_maps=$(grep -E "^[0-9a-f-]* r" /proc/"$pid"/maps | cut -d' ' -f 1)
 	fi
 	while read -r memrange; do
 		memrange_start=$(echo "$memrange" | cut -d"-" -f 1)


### PR DESCRIPTION
This PR reverts #38 due to causing false-negatives with `gdm-password`.